### PR TITLE
Newer Version with default WordPress sending address

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -23,12 +23,12 @@ A sample configuration:
  * WordPress SMTP server
  */
 define('WP_SMTP_HOST',       'mail.example.com');
-define('WP_SMTP_PORT',       25);                                // obligatory - default: 25
-define('WP_SMTP_ENCRYPTION', 'tls');                             // obligatory ('tls' or 'ssl') - default: no encryption
+define('WP_SMTP_PORT',        465);                              // obligatory - default: 25
+define('WP_SMTP_ENCRYPTION', 'ssl');                             // obligatory ('tls' or 'ssl') - default: no encryption
 define('WP_SMTP_USER',       'username');                        // obligatory - default: no user
 define('WP_SMTP_PASSWORD',   'password');                        // obligatory - default: no password
-define('WP_SMTP_FROM',       'John Doe <john.doe@example.com>'); // obligatory - default: no custom from address
-define('WP_SMTP_REPLYTO',    'Jane Doe <jane.doe@example.com>'); // obligatory - default: no custom reply to address
+define('WP_SMTP_FROM',       'John Doe <john.doe@example.com>'); // obligatory - default from WordPress: wordpress@example.com, is also set as default wordpress sending address
+define('WP_SMTP_REPLYTO',    'Jane Doe <jane.doe@example.com>'); // obligatory - default: no, custom reply to address
 `
 
 == Installation ==
@@ -47,6 +47,12 @@ You can test your configuration in `Settings -> SMTP Test`.
 If you are running a MU installation you will find this settings page for SMTP Test in your network settings.
 
 == Changelog ==
+
+= 1.3.0 =
+* Code rework
+* Fixed bug default wordpress sending address is set to setting
+* Added help on admin page
+* Added copy button for settings on admin page
 
 = 1.2.0 =
 * Fixed bug settings page not showing for network admin

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: pCoLaSD, holzhannes
 Tags: email, mail, phpmailer, smtp, ssl, tls, wp_mail, wpmu, multisite, network
 Requires at least: 3.0
-Tested up to: 4.9.8
-Stable tag: 1.2.0
+Tested up to: 6.9.0
+Stable tag: 1.3.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/wp-smtp-config.php
+++ b/wp-smtp-config.php
@@ -207,7 +207,8 @@ function wp_smtp_config_options_page_save() {
 			'There was an error while trying to send the test email.',
 		);
 
-		$recipient = isset( $_POST['smtp_recipient'] ) ? trim( wp_unslash( $_POST['smtp_recipient'] ) ) : '';
+		$recipient_raw = isset( $_POST['smtp_recipient'] ) ? wp_unslash( $_POST['smtp_recipient'] ) : '';
+        $recipient = sanitize_email( $recipient_raw);
 
 		if ( is_email( $recipient ) ) {
 

--- a/wp-smtp-config.php
+++ b/wp-smtp-config.php
@@ -266,7 +266,7 @@ function wp_smtp_config_options_page() {
 		<h2><?php esc_html_e( 'Send a Test Email', 'wp-smtp-config' ); ?></h2>
 		<p><?php esc_html_e( 'Enter a valid email address below to send a test message.', 'wp-smtp-config' ); ?></p>
 
-		<form method="post" action="">
+		<form method="post" action="<?php echo esc_url( admin_url( 'options-general.php?page=wp-smtp-config' ) ); ?>">
 			<?php wp_nonce_field( 'wp_smtp_config_test_email' ); ?>
 
 			<table class="form-table" role="presentation">

--- a/wp-smtp-config.php
+++ b/wp-smtp-config.php
@@ -1,143 +1,366 @@
 <?php
+/*
+Plugin Name: WP SMTP Config
+Plugin URI:  https://github.com/holzhannes/wp-smtp-config-plugin
+Description: Configure an external SMTP server via wp-config.php constants and send a test email. Uses WP_SMTP_* constants.
+Version:     1.3.0
+Author:      Daniel Schröder, holzhannes
+License:     GPL-2.0-or-later
+*/
+
 /**
- * Plugin Name:     WP SMTP Config
- * Plugin URI:      http://wordpress.org/extend/plugins/wp-smtp-config/
- * Description:     Configure an external SMTP server in your config file.
- * Author:          Daniel Schröder, holzhannes
- * Author URI:      https://github.com/schroedan
- * License:         GNU General Public License 2.0 (GPL) http://www.gnu.org/licenses/gpl-2.0.html
- * Version:         1.2.0
+ * Helper: Parse a "Name <email@example.com>" or "email@example.com" string.
  *
- * @package         WP_SMTP_Config
+ * @param string $raw Raw address string.
+ * @return array{email:string,name:string}
  */
+function wp_smtp_config_parse_address( $raw ) {
+	if ( ! is_string( $raw ) || $raw === '' ) {
+		return array(
+			'email' => '',
+			'name'  => '',
+		);
+	}
 
-if ( defined( 'WP_SMTP_HOST' ) && is_string( WP_SMTP_HOST ) ) {
+	$raw   = trim( $raw );
+	$email = '';
+	$name  = '';
 
-	/**
-	 * PHPMailer init action.
-	 *
-	 * @param PHPMailer $phpmailer The PHPMailer instance.
-	 *
-	 * @return void
-	 */
-	function wp_smtp_config_phpmailer_init( $phpmailer ) {
-		$phpmailer->isSMTP();
-		$phpmailer->Host = WP_SMTP_HOST;
+	// Format: "Name <email@example.com>"
+	if ( preg_match( '/^(.*)<(.+)>$/', $raw, $matches ) ) {
+		$name_candidate  = trim( $matches[1] );
+		$email_candidate = trim( $matches[2] );
+	} else {
+		// Only email address.
+		$name_candidate  = '';
+		$email_candidate = $raw;
+	}
 
-		if ( defined( 'WP_SMTP_PORT' ) && is_int( WP_SMTP_PORT ) ) {
-			$phpmailer->Port = WP_SMTP_PORT;
-		}
+	if ( is_email( $email_candidate ) ) {
+		$email = $email_candidate;
+	}
 
-		if ( defined( 'WP_SMTP_ENCRYPTION' ) && in_array( WP_SMTP_ENCRYPTION, array( 'ssl', 'tls' ), true ) ) {
-			$phpmailer->SMTPSecure = WP_SMTP_ENCRYPTION;
-		}
+	if ( $name_candidate !== '' ) {
+		$name = sanitize_text_field( $name_candidate );
+	}
 
-		if ( defined( 'WP_SMTP_USER' ) && is_string( WP_SMTP_USER ) ) {
-			$phpmailer->SMTPAuth = true;
-			$phpmailer->Username = WP_SMTP_USER;
+	return array(
+		'email' => $email,
+		'name'  => $name,
+	);
+}
 
-			if ( defined( 'WP_SMTP_PASSWORD' ) && is_string( WP_SMTP_PASSWORD ) ) {
-				$phpmailer->Password = WP_SMTP_PASSWORD;
-			}
-		}
+/**
+ * Helper: Get FROM address parts from WP_SMTP_FROM.
+ *
+ * @return array{email:string,name:string}
+ */
+function wp_smtp_config_get_from_parts() {
+	if ( ! defined( 'WP_SMTP_FROM' ) ) {
+		return array(
+			'email' => '',
+			'name'  => '',
+		);
+	}
 
-		if ( defined( 'WP_SMTP_REPLYTO' ) && preg_match( '/^(?P<replyname>.+?)(<(?P<replyto>.*)>)?$/', WP_SMTP_REPLYTO, $matches ) > 0 ) {
-			if ( isset( $matches['replyto'] ) && isset( $matches['replyname'] ) && is_email( $matches['replyto'] )) {
-				$phpmailer->AddReplyTo($matches['replyto'], sanitize_text_field($matches['replyname']));
-			}
-			if ( isset( $matches['replyname'] ) && is_email( $matches['replyname'] ) ) {
-				$phpmailer->AddReplyTo($matches['replyname']);
-			}
-		}
+	return wp_smtp_config_parse_address( WP_SMTP_FROM );
+}
 
-		if ( defined( 'WP_SMTP_FROM' ) && preg_match( '/^(?P<name>.+?)(<(?P<from>.*)>)?$/', WP_SMTP_FROM, $matches ) > 0 ) {
-			if ( isset( $matches['from'] ) && is_email( $matches['from'] ) ) {
-				$phpmailer->SetFrom($matches['from'], sanitize_text_field($matches['name']) );
-			}
-			if ( isset( $matches['name'] ) && is_email( $matches['name'] ) ){
-				$phpmailer->SetFrom($matches['name']);
-			}
+/**
+ * Configure PHPMailer using WP_SMTP_* constants.
+ *
+ * @param PHPMailer $phpmailer PHPMailer instance (passed by reference).
+ */
+function wp_smtp_config_phpmailer_init( $phpmailer ) {
+
+	if ( ! defined( 'WP_SMTP_HOST' ) || ! is_string( WP_SMTP_HOST ) || WP_SMTP_HOST === '' ) {
+		// Nothing to do if no host is defined.
+		return;
+	}
+
+	// Basic SMTP setup.
+	$phpmailer->isSMTP();
+	$phpmailer->Host = WP_SMTP_HOST;
+
+	// Port.
+	if ( defined( 'WP_SMTP_PORT' ) && WP_SMTP_PORT ) {
+		$phpmailer->Port = (int) WP_SMTP_PORT;
+	}
+
+	// Encryption: 'ssl' or 'tls'.
+	if ( defined( 'WP_SMTP_ENCRYPTION' ) && is_string( WP_SMTP_ENCRYPTION ) ) {
+		$encryption = strtolower( WP_SMTP_ENCRYPTION );
+		if ( in_array( $encryption, array( 'ssl', 'tls' ), true ) ) {
+			$phpmailer->SMTPSecure = $encryption;
 		}
 	}
 
-	add_action( 'phpmailer_init', 'wp_smtp_config_phpmailer_init' );
+	// Auth / credentials.
+	if ( defined( 'WP_SMTP_USER' ) && is_string( WP_SMTP_USER ) && WP_SMTP_USER !== '' ) {
+		$phpmailer->SMTPAuth = true;
+		$phpmailer->Username = WP_SMTP_USER;
 
-	function wp_smtp_config_network_admin_menu() {
-		add_submenu_page( 'settings.php', 'SMTP Settings', 'SMTP Test', 'manage_network_options', 'wp-smtp-config', 'wp_smtp_config_options_page' );
+		if ( defined( 'WP_SMTP_PASSWORD' ) && is_string( WP_SMTP_PASSWORD ) ) {
+			$phpmailer->Password = WP_SMTP_PASSWORD;
+		}
 	}
 
-	function wp_smtp_config_admin_menu() {
-		add_options_page( 'SMTP Settings', 'SMTP Test', 'manage_options', 'wp-smtp-config', 'wp_smtp_config_options_page' );
-	}
+	// Reply-To.
+	if ( defined( 'WP_SMTP_REPLYTO' ) && is_string( WP_SMTP_REPLYTO ) && WP_SMTP_REPLYTO !== '' ) {
+		$reply_parts = wp_smtp_config_parse_address( WP_SMTP_REPLYTO );
 
-	function wp_smtp_config_options_page_save() {
-		global $phpmailer;
-
-		if ( isset( $_POST['smtp_submit'] ) && $_POST['smtp_submit'] == 'Send' && isset( $_POST['smtp_recipient'] ) ) {
-			$message          = new stdClass();
-			$message->error   = true;
-			$message->title   = 'Test Email Failure';
-			$message->content = array( 'There was an error while trying to send the test email.' );
-
-			if ( is_email( $_POST['smtp_recipient'] ) ) {
-				if ( wp_mail( $_POST['smtp_recipient'], 'SMTP Test', 'If you received this email it means you have configured SMTP correctly on your WordPress website.' ) ) {
-					$message->error   = false;
-					$message->title   = 'Test Email Success';
-					$message->content = array( 'The test email was sent successfully.' );
-
-					return $message;
-				}
-				$error = ( is_object( $phpmailer ) && is_a( $phpmailer, 'PHPMailer' ) ) ? $phpmailer->ErrorInfo : '';
-				if ( ! empty( $error ) ) {
-					array_push( $message->content, $error );
-				}
-			} elseif ( empty( $_POST['smtp_recipient'] ) ) {
-				array_push( $message->content, 'Please enter a valid email address.' );
+		if ( ! empty( $reply_parts['email'] ) ) {
+			if ( $reply_parts['name'] !== '' ) {
+				$phpmailer->addReplyTo( $reply_parts['email'], $reply_parts['name'] );
 			} else {
-				array_push( $message->content, $_POST['smtp_recipient'] . ' is no valid email address.' );
+				$phpmailer->addReplyTo( $reply_parts['email'] );
 			}
-
-			return $message;
 		}
-
-		return null;
 	}
 
-	function wp_smtp_config_options_page() {
-		$message = wp_smtp_config_options_page_save();
-		?>
-		<?php if ( is_object( $message ) ) : ?>
-			<div id="smtp-message" class="<?php echo esc_attr( $message->error ? 'error' : 'updated fade' ); ?>">
+	// FROM (Adress- und ggf. Name) aus WP_SMTP_FROM – nutzt denselben Helper wie die Filter unten.
+	$from_parts = wp_smtp_config_get_from_parts();
+
+	if ( ! empty( $from_parts['email'] ) ) {
+		$from_name = $from_parts['name'] !== '' ? $from_parts['name'] : $phpmailer->FromName;
+		// Drittes Argument: do not auto-rewrite if already set.
+		$phpmailer->setFrom( $from_parts['email'], $from_name, false );
+	}
+}
+
+/**
+ * Filter: Override wp_mail() "from" address using WP_SMTP_FROM.
+ *
+ * @param string $from Current from email.
+ * @return string
+ */
+function wp_smtp_config_mail_from( $from ) {
+	$parts = wp_smtp_config_get_from_parts();
+
+	if ( ! empty( $parts['email'] ) ) {
+		return $parts['email'];
+	}
+
+	return $from;
+}
+
+/**
+ * Filter: Override wp_mail() "from name" using WP_SMTP_FROM (if a name is present).
+ *
+ * @param string $from_name Current from name.
+ * @return string
+ */
+function wp_smtp_config_mail_from_name( $from_name ) {
+	$parts = wp_smtp_config_get_from_parts();
+
+	// Only override when a readable name is configured.
+	if ( ! empty( $parts['name'] ) ) {
+		return $parts['name'];
+	}
+
+	return $from_name;
+}
+
+/**
+ * Add SMTP Test menu to network admin.
+ */
+function wp_smtp_config_network_admin_menu() {
+	add_submenu_page(
+		'settings.php',
+		'SMTP Settings',
+		'SMTP Test',
+		'manage_network_options',
+		'wp-smtp-config',
+		'wp_smtp_config_options_page'
+	);
+}
+
+/**
+ * Add SMTP Test menu to normal admin.
+ */
+function wp_smtp_config_admin_menu() {
+	add_options_page(
+		'SMTP Settings',
+		'SMTP Test',
+		'manage_options',
+		'wp-smtp-config',
+		'wp_smtp_config_options_page'
+	);
+}
+
+/**
+ * Handle form submission on the SMTP test page.
+ *
+ * @return stdClass|null
+ */
+function wp_smtp_config_options_page_save() {
+	global $phpmailer;
+
+	if ( isset( $_POST['smtp_submit'], $_POST['smtp_recipient'] ) && $_POST['smtp_submit'] === 'Send' ) {
+
+		check_admin_referer( 'wp_smtp_config_test_email' );
+
+		$message          = new stdClass();
+		$message->error   = true;
+		$message->title   = 'Test Email Failure';
+		$message->content = array(
+			'There was an error while trying to send the test email.',
+		);
+
+		$recipient = isset( $_POST['smtp_recipient'] ) ? trim( wp_unslash( $_POST['smtp_recipient'] ) ) : '';
+
+		if ( is_email( $recipient ) ) {
+
+			if ( wp_mail(
+				$recipient,
+				'SMTP Test',
+				'If you received this email it means you have configured SMTP correctly on your WordPress website.'
+			) ) {
+				$message->error   = false;
+				$message->title   = 'Test Email Success';
+				$message->content = array(
+					'The test email was sent successfully.',
+				);
+
+				return $message;
+			}
+
+			$error = ( is_object( $phpmailer ) && is_a( $phpmailer, 'PHPMailer' ) ) ? $phpmailer->ErrorInfo : '';
+			if ( ! empty( $error ) ) {
+				$message->content[] = $error;
+			}
+		} elseif ( $recipient === '' ) {
+			$message->content[] = 'Please enter a valid email address.';
+		} else {
+			$message->content[] = sprintf(
+				'%s is no valid email address.',
+				esc_html( $recipient )
+			);
+		}
+
+		return $message;
+	}
+
+	return null;
+}
+
+/**
+ * Render SMTP Test settings page.
+ */
+function wp_smtp_config_options_page() {
+	$message = wp_smtp_config_options_page_save();
+	?>
+	<div class="wrap">
+		<h1><?php esc_html_e( 'SMTP Settings', 'wp-smtp-config' ); ?></h1>
+
+		<?php if ( $message instanceof stdClass ) : ?>
+			<div class="<?php echo $message->error ? 'notice notice-error' : 'notice notice-success'; ?>">
 				<p><strong><?php echo esc_html( $message->title ); ?></strong></p>
 				<?php foreach ( $message->content as $content ) : ?>
 					<p><?php echo esc_html( $content ); ?></p>
 				<?php endforeach; ?>
 			</div>
 		<?php endif; ?>
-		<div class="wrap">
-			<div class="icon32" id="icon-options-general"><br/></div>
-			<h2>SMTP Settings</h2>
-			<h3>Send a Test Email</h3>
-			<p>Enter a valid email address below to send a test message.</p>
-			<form method="post">
-				<table class="optiontable form-table">
-					<tr valign="top">
-						<th scope="row"><label for="smtp_recipient">Recipient:</label></th>
-						<td><input id="smtp_recipient" name="smtp_recipient" type="text" value="" class="regular-text"/>
-						</td>
-					</tr>
-				</table>
-				<p class="submit">
-					<input type="submit" name="smtp_submit" class="button-primary" value="Send"/>
-				</p>
-			</form>
-		</div>
-		<?php
-	}
 
-	if ( is_multisite() ) {
-		add_action( 'network_admin_menu', 'wp_smtp_config_network_admin_menu' );
-	} else {
-		add_action( 'admin_menu', 'wp_smtp_config_admin_menu' );
-	}
+		<h2><?php esc_html_e( 'Send a Test Email', 'wp-smtp-config' ); ?></h2>
+		<p><?php esc_html_e( 'Enter a valid email address below to send a test message.', 'wp-smtp-config' ); ?></p>
+
+		<form method="post" action="">
+			<?php wp_nonce_field( 'wp_smtp_config_test_email' ); ?>
+
+			<table class="form-table" role="presentation">
+				<tr>
+					<th scope="row">
+						<label for="smtp_recipient"><?php esc_html_e( 'Recipient', 'wp-smtp-config' ); ?></label>
+					</th>
+					<td>
+						<input type="email" class="regular-text" name="smtp_recipient" id="smtp_recipient"
+						       value="<?php echo isset( $_POST['smtp_recipient'] ) ? esc_attr( wp_unslash( $_POST['smtp_recipient'] ) ) : ''; ?>">
+					</td>
+				</tr>
+			</table>
+
+			<?php submit_button( __( 'Send', 'wp-smtp-config' ), 'primary', 'smtp_submit' ); ?>
+		</form>
+
+		<hr />
+
+		<h2><?php esc_html_e( 'Configuration via wp-config.php', 'wp-smtp-config' ); ?></h2>
+		<p><?php esc_html_e( 'This plugin reads the following constants from wp-config.php:', 'wp-smtp-config' ); ?></p>
+		<?php
+		$config_snippet = "/**
+ * WordPress SMTP server settings
+ */
+define('WP_SMTP_HOST',       'mail.example.com');
+define('WP_SMTP_PORT',        465);                              // obligatory - default: 25
+define('WP_SMTP_ENCRYPTION', 'ssl');                             // obligatory ('tls' or 'ssl') - default: no encryption
+define('WP_SMTP_USER',       'username');                        // obligatory - default: no user
+define('WP_SMTP_PASSWORD',   'password');                        // obligatory - default: no password
+define('WP_SMTP_FROM',       'John Doe <john.doe@example.com>'); // obligatory - default: no custom from address also set as default wordpress sending address
+define('WP_SMTP_REPLYTO',    'Jane Doe <jane.doe@example.com>'); // obligatory - default: no custom reply to address";
+		?>
+		<textarea id="wp-smtp-config-snippet"
+		          class="large-text code"
+		          rows="11"
+		          readonly="readonly"><?php echo esc_textarea( $config_snippet ); ?></textarea>
+
+		<p style="margin-top:8px;">
+			<button type="button" class="button" id="wp-smtp-config-copy">
+				<?php esc_html_e( 'Copy to clipboard', 'wp-smtp-config' ); ?>
+			</button>
+			<span id="wp-smtp-config-copy-feedback" style="margin-left:8px;"></span>
+		</p>
+
+		<script>
+		(function() {
+			const btn = document.getElementById('wp-smtp-config-copy');
+			const ta  = document.getElementById('wp-smtp-config-snippet');
+			const fb  = document.getElementById('wp-smtp-config-copy-feedback');
+
+			if (!btn || !ta) {
+				return;
+			}
+
+			btn.addEventListener('click', function (event) {
+				event.preventDefault();
+
+				ta.focus();
+				ta.select();
+
+				// Versuche Clipboard API, fallback auf execCommand.
+				if (navigator.clipboard && navigator.clipboard.writeText) {
+					navigator.clipboard.writeText(ta.value).then(function () {
+						if (fb) {
+							fb.textContent = '<?php echo esc_js( __( 'Copied!', 'wp-smtp-config' ) ); ?>';
+							setTimeout(function () { fb.textContent = ''; }, 2000);
+						}
+					}).catch(function () {
+						document.execCommand('copy');
+						if (fb) {
+							fb.textContent = '<?php echo esc_js( __( 'Copied (fallback).', 'wp-smtp-config' ) ); ?>';
+							setTimeout(function () { fb.textContent = ''; }, 2000);
+						}
+					});
+				} else {
+					// Fallback für ältere Browser.
+					const success = document.execCommand('copy');
+					if (fb) {
+						fb.textContent = success
+							? '<?php echo esc_js( __( 'Copied!', 'wp-smtp-config' ) ); ?>'
+							: '<?php echo esc_js( __( 'Copy failed – please copy manually.', 'wp-smtp-config' ) ); ?>';
+						setTimeout(function () { fb.textContent = ''; }, 2000);
+					}
+				}
+			});
+		})();
+		</script>
+	</div>
+	<?php
 }
+
+// Hooks.
+add_action( 'phpmailer_init', 'wp_smtp_config_phpmailer_init' );
+add_filter( 'wp_mail_from', 'wp_smtp_config_mail_from' );
+add_filter( 'wp_mail_from_name', 'wp_smtp_config_mail_from_name' );
+add_action( 'network_admin_menu', 'wp_smtp_config_network_admin_menu' );
+add_action( 'admin_menu', 'wp_smtp_config_admin_menu' );


### PR DESCRIPTION
- Code rework
- Fixed bug: default WordPress sending address is set to value from WP_SMTP_FROM setting
- Added help on admin page
- Added copy button for settings on admin page
- Some security hardenings